### PR TITLE
New title format

### DIFF
--- a/themes/vimways/layouts/partials/head.html
+++ b/themes/vimways/layouts/partials/head.html
@@ -2,7 +2,7 @@
 	<meta charset="utf-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
-	<title>{{ .Site.Title }} ~ {{ .Title }}</title>
+	<title>{{ .Title }} · {{ .Site.Title }}</title>
 
 	<!-- analytics -->
 	{{ template "_internal/google_analytics_async.html" . }}


### PR DESCRIPTION
Hi, I’ve noticed that vimways.org uses an ASCII tilde as a separator in the HTML title of each page. I, IMHO, found that slightly odd, since a nicer-looking (again, IMO) Unicode character could be used. I also found it a bit strange that the website title came _before_ the name of the specific page, since (in my experience) most websites do it the other way around.

This PR changes the title format to match my suggestions above.

Thanks for creating such a cool website, the articles have been really helpful!