### PR TITLE
Remove 'r' flag from example

### DIFF
--- a/content/2018/tejr-runtime-hackery.md
+++ b/content/2018/tejr-runtime-hackery.md
@@ -105,7 +105,7 @@ enough, the `r` flag has gone, and the unwanted behavior has stopped.
 
 ```vim
 :set formatoptions?
-  formatoptions=jcrqol
+  formatoptions=jcqol
 ```
 
 Note that you didn’t need to add a [`b:undo_ftplugin`][uf] command in this


### PR DESCRIPTION
The text just above this code asserts that the flag is gone, and yet it's still there...