### PR TITLE
Two corrections to "From .vimrc to .vim"

### DIFF
--- a/content/2018/tejr-from-vimrc-to-vim.md
+++ b/content/2018/tejr-from-vimrc-to-vim.md
@@ -269,7 +269,7 @@ loaded:
 ```vim
 if &compatible
       \ || v:version < 700
-      \ || has('folding')
+      \ || !has('folding')
       \ || exists('g:loaded_myplugin')
   finish
 endif

--- a/content/2018/tejr-from-vimrc-to-vim.md
+++ b/content/2018/tejr-from-vimrc-to-vim.md
@@ -207,7 +207,7 @@ set *before* the function it calls was defined.
 Why should we put the script in `~/.vim/plugin`? You might object that our
 example isn’t a *real* plugin; it’s just a single function. However, that’s not
 a meaningful distinction to Vim. At startup, it sources any and all `.vim`
-files in the `plugins` subdirectory of each of the directories in
+files in the `plugin` subdirectory of each of the directories in
 `'runtimepath'`. It makes no difference what those files actually contain. A
 set of related abbreviations? Custom commands? Code dependent on one particular
 machine or operating system? Sure, why not?


### PR DESCRIPTION
Correct name of plugin subdir (remove plural), and negate one of the conditions in the load guard example to take a much more likely form.