### PR TITLE
fix typo (testing second entry of popup menu)

### DIFF
--- a/content/2019/a-test-to-attest-to/index.md
+++ b/content/2019/a-test-to-attest-to/index.md
@@ -770,7 +770,7 @@ endfunction
 function Test_Simple_May()
   " Use C-n to prove that the second option is May
   call feedkeys( "iM\<C-x>\<C-u>\<C-n>", 'xt' )
-  call assert_equal( 'Mar', getline( 1 ) )
+  call assert_equal( 'May', getline( 1 ) )
   %bwipe!
 endfunction
 ```


### PR DESCRIPTION
looks like copy and paste error

BTW: very nice article on the testing framework.

While you at it, please also note the missing license. I might have misunderstood the `license note` part, but anyhow I'd suggest it should probably be either made explicit (or just removed).